### PR TITLE
依赖项更新

### DIFF
--- a/BiliAccount.Geetest.Controls/BiliAccount.Geetest.Controls.csproj
+++ b/BiliAccount.Geetest.Controls/BiliAccount.Geetest.Controls.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <RootNamespace>BiliAccount.Geetest.Controls</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>   
-    <Version>1.0.1.1</Version>
+    <Version>1.0.3.3</Version>
     <Authors>LeoChen</Authors>
     <Company>zhangbudademao.com</Company>
     <Copyright>Copyright © 2020 zhangbudademao.com, all rights reserved.</Copyright>
@@ -17,8 +17,11 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>bilibili bililive bililogin biliaccount</PackageTags>
     <PackageIcon>favicon_4.png</PackageIcon>
-    <PackageReleaseNotes>1. 更新BiliAccount.Geetest版本到1.0.3.3。
-2. 更新Chromium内核版本到81。
+    <PackageReleaseNotes>
+      enhancements:
+        1. 更新了BiliAccount到2.5.2.24(fixed #49)
+        2. 更新BiliAccount.Geetest版本到1.0.4.4。
+        3. 更新Chromium内核版本到85。（安全更新）
     </PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -146,8 +149,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="BiliAccount" Version="2.5.0.22" />
-    <PackageReference Include="BiliAccount.Geetest" Version="1.0.3.3" />
+    <PackageReference Include="BiliAccount" Version="2.5.2.24" />
+    <PackageReference Include="BiliAccount.Geetest" Version="1.0.4.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/BiliAccount.Geetest/BiliAccount.Geetest.csproj
+++ b/BiliAccount.Geetest/BiliAccount.Geetest.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>BiliAccount.Geetest</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>BiliAccount.Geetest</PackageId>
-    <Version>1.0.3.3</Version>
+    <Version>1.0.4.4</Version>
     <Authors>LeoChen</Authors>
     <Company>zhangbudademao.com</Company>
     <Product>BiliAccount.Geetest</Product>
@@ -18,7 +18,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>bilibili bililive bililogin biliaccount</PackageTags>
     <PackageIcon>favicon_4.png</PackageIcon>
-    <PackageReleaseNotes>移除不必要的引用
+    <PackageReleaseNotes>
+      enhancements:
+          1. 更新了BiliAccount到2.5.2.24
+          2. 更新了Titanium.Web.Proxy到3.1.1341
     </PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -108,7 +111,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Release'">
-    <PackageReference Include="BiliAccount" Version="2.5.0.22" />
+    <PackageReference Include="BiliAccount" Version="2.5.2.24" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">
@@ -116,7 +119,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1301" />
+    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1341" />
   </ItemGroup>
 
 </Project>

--- a/BiliAccount/BiliAccount.csproj
+++ b/BiliAccount/BiliAccount.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>BiliAccount</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>BiliAccount</PackageId>
-    <Version>2.5.1.23</Version>
+    <Version>2.5.2.24</Version>
     <Authors>LeoChen</Authors>
     <Company>zhangbudademao.com</Company>
     <Product>BiliAccount</Product>
@@ -19,8 +19,10 @@
     <PackageTags>bilibili bililive bililogin biliaccount</PackageTags>
     <PackageIcon>favicon_4.png</PackageIcon>
     <PackageReleaseNotes>
-     fixes:
-        1. 修复 `ByQRCode.LoginByQrCode` 方法背景色存在透明度时，二维码绘制概率性出现无前景色的问题。(#47)
+     enhancements:
+        1. 更新了QRCoder到1.4.1版本（针对.net standard和.net core平台）
+        2. 更新了System.Drawing.Common到5.0.0（针对.net standard和.net core平台）
+        3. 优化了对SSO过程中对低版本IDE环境的兼容性。(#18)
     </PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -106,9 +108,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="QRCoder" Version="1.3.9" />
+    <PackageReference Include="QRCoder" Version="1.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BiliAccount/Core/ByPassword.cs
+++ b/BiliAccount/Core/ByPassword.cs
@@ -290,6 +290,24 @@ namespace BiliAccount.Core
                         csrf_token = tmp2[1];
                 }
                 cookies = cookies.Substring(0, cookies.Length - 2);
+            }catch(WebException wex)
+            {
+                if(wex.Status == WebExceptionStatus.ProtocolError && ((HttpWebResponse)wex.Response).StatusCode == HttpStatusCode.Found)
+                {
+                    foreach (string i in ((HttpWebResponse)wex.Response).Headers.GetValues("Set-Cookie"))
+                    {
+                        string[] tmp = i.Split(';');
+                        string[] tmp2 = tmp[0].Split('=');
+
+                        cookies += tmp[0] + "; ";
+                        cookiesC.Add(new Cookie(tmp2[0], tmp2[1]) { Domain = ".bilibili.com" });
+                        expires = DateTime.Parse(tmp[2].Split('=')[1]);
+
+                        if (tmp2[0] == "bili_jct")
+                            csrf_token = tmp2[1];
+                    }
+                    cookies = cookies.Substring(0, cookies.Length - 2);
+                }
             }
             finally
             {

--- a/BiliAccount/Init.json
+++ b/BiliAccount/Init.json
@@ -1,7 +1,7 @@
 ﻿{
   "appkey": "bca7e84c2d947ac6",
   "appsecret": "60698ba2f68e01ce44738920a0ffe768",
-  "build": "6100500",
-  "version": "6.10.0",
-  "user_agent": "Mozilla/5.0 BiliDroid/6.10.0(bbcallen@gmail.com) os/android model/MI 9 mobi_app/android build/6100500 channel/master innerVer/6100500 osVer/10 network/2"
+  "build": "6130400",
+  "version": "6.13.0",
+  "user_agent": "Mozilla/5.0 BiliDroid/6.13.0(bbcallen@gmail.com) os/android model/MI 9 mobi_app/android build/6130400 channel/master innerVer/6130400 osVer/10 network/2"
 }


### PR DESCRIPTION
**General**
1. 更新了初始化信息到安卓客户端6.13.0版本

**BiliAccount@2.5.2.24**
1. 更新了QRCoder到1.4.1版本（针对.net standard和.net core平台）
2. 更新了System.Drawing.Common到5.0.0（针对.net standard和.net core平台）(fixed #56)
3. 优化了对SSO过程中对低版本IDE环境的兼容性。(fixed #18)

**BiliAccount.Geetest@1.0.4.4**
1. 更新了BiliAccount到2.5.2.24(fixed #49)
2. 更新了Titanium.Web.Proxy到3.1.1341

**BiliAccount.Geetest.Controls@1.0.3.3**-未发布，发布时间待定
1. 更新了BiliAccount到2.5.2.24(fixed #49)
2. 更新BiliAccount.Geetest版本到1.0.4.4。
3. 更新Chromium内核版本到85。（安全更新）