### PR TITLE
[BiliAccount @ 2.5.4.26]

### DIFF
--- a/BiliAccount/BiliAccount.csproj
+++ b/BiliAccount/BiliAccount.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>BiliAccount</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>BiliAccount</PackageId>
-    <Version>2.5.3.25</Version>
+    <Version>2.5.4.26</Version>
     <Authors>LeoChen</Authors>
     <Company>zhangbudademao.com</Company>
     <Product>BiliAccount</Product>
@@ -19,8 +19,8 @@
     <PackageTags>bilibili bililive bililogin biliaccount</PackageTags>
     <PackageIcon>favicon_4.png</PackageIcon>
     <PackageReleaseNotes>
-     enhancements:
-        1. 修改登录接口UA
+     fixes:
+	    1. 修复了由于破站改接口导致无法通过密码登录的问题。
     </PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/BiliAccount/Core/ByPassword.cs
+++ b/BiliAccount/Core/ByPassword.cs
@@ -50,10 +50,10 @@ namespace BiliAccount.Core
             /* 旧版参数
              * string parm = "appkey=" + Config.Instance.Appkey + "&build=" + Config.Instance.Build + "&mobi_app=android&password=" + account.EncryptedPassword + "&platform=android&ts=" + TimeStamp + "&username=" + account.UserName;
              */
-            string parm = $"appkey={Config.Instance.Appkey}&bili_local_id={account.DeviceId}&build={Config.Instance.Build}&buvid={account.Buvid}&channel=bili&device=phone&device_id={account.DeviceId}&device_name=BiliAccount{account.DeviceGuid}&device_platform=BiliAccount{Assembly.GetExecutingAssembly().GetName().Version}&local_id={account.Buvid}&mobi_app=android&password={account.EncryptedPassword}&platform=android&statistics=%7B%22appId%22%3A1%2C%22platform%22%3A3%2C%22version%22%3A%22{Config.Instance.Version}%22%2C%22abtest%22%3A%22%22%7D&ts={TimeStamp}&username={account.UserName}";
+            string parm = $"appkey={Config.Instance.Appkey}&bili_local_id={account.DeviceId}&build={Config.Instance.Build}&buvid={account.Buvid}&channel=bili&device=phone&device_id={account.DeviceId}&device_name=BiliAccount{account.DeviceGuid}&device_platform=BiliAccount{Assembly.GetExecutingAssembly().GetName().Version}&from_pv=main.my-information.my-login.0.click&from_url=bilibili%3A%2F%2Fuser_center%2Fmine&local_id={account.Buvid}&mobi_app=android&password={account.EncryptedPassword}&platform=android&statistics=%7B%22appId%22%3A1%2C%22platform%22%3A3%2C%22version%22%3A%22{Config.Instance.Version}%22%2C%22abtest%22%3A%22%22%7D&ts={TimeStamp}&username={account.UserName}";
             parm += "&sign=" + GetSign(parm);
             //string str = Http.PostBodyOutCookies("http://passport.bilibili.com/api/v3/oauth2/login", out account.Cookies, parm, null, "application/x-www-form-urlencoded;charset=utf-8", "", Config.Instance.User_Agent);
-            string str = Http.PostBodyOutCookies("http://passport.bilibili.com/api/v3/oauth2/login", out account.Cookies, parm, null, "application/x-www-form-urlencoded;charset=utf-8", "", $"BiliAccount/{Config.Dll_Version}");
+            string str = Http.PostBodyOutCookies("https://passport.bilibili.com/x/passport-login/oauth2/login ", out account.Cookies, parm, null, "application/x-www-form-urlencoded;charset=utf-8", "", $"BiliAccount/{Config.Dll_Version}");
             if (!string.IsNullOrEmpty(str))
             {
 #if NETSTANDARD2_0 || NETCORE3_0
@@ -95,7 +95,7 @@ namespace BiliAccount.Core
             string parm = "actionKey=" + Config.Instance.Appkey + "&appkey=" + Config.Instance.Appkey + "&build=" + Config.Instance.Build + "&captcha=" + captcha + "&mobi_app=android&password=" + account.EncryptedPassword + "&device=android&platform=android&ts=" + TimeStamp + "&username=" + account.UserName;
             parm += "&sign=" + GetSign(parm);
             //string str = Http.PostBodyOutCookies("http://passport.bilibili.com/api/v3/oauth2/login", out account.Cookies, parm, account.Cookies, "application/x-www-form-urlencoded;charset=utf-8", "", Config.Instance.User_Agent);
-            string str = Http.PostBodyOutCookies("http://passport.bilibili.com/api/v3/oauth2/login", out account.Cookies, parm, account.Cookies, "application/x-www-form-urlencoded;charset=utf-8", "", $"BiliAccount/{Config.Dll_Version}");
+            string str = Http.PostBodyOutCookies("https://passport.bilibili.com/x/passport-login/oauth2/login", out account.Cookies, parm, account.Cookies, "application/x-www-form-urlencoded;charset=utf-8", "", $"BiliAccount/{Config.Dll_Version}");
             if (!string.IsNullOrEmpty(str))
             {
 #if NETSTANDARD2_0 || NETCORE3_0
@@ -371,7 +371,7 @@ namespace BiliAccount.Core
                     account.Uid = obj.data.token_info.mid;
                     account.AccessToken = obj.data.token_info.access_token;
                     account.RefreshToken = obj.data.token_info.refresh_token;
-                    account.Expires_AccessToken = DateTime.Parse("1970-01-01 08:00:00").AddSeconds(obj.ts + obj.data.token_info.expires_in);
+                    account.Expires_AccessToken = DateTime.Now.AddSeconds(obj.data.token_info.expires_in);
 
                     account.Cookies = new CookieCollection();
                     foreach (DoLogin_DataTemplete.Data_Templete.Cookie_Info_Templete.Cookie_Templete i in obj.data.cookie_info.cookies)

--- a/BiliAccount/Init.json
+++ b/BiliAccount/Init.json
@@ -1,7 +1,7 @@
 ﻿{
   "appkey": "bca7e84c2d947ac6",
   "appsecret": "60698ba2f68e01ce44738920a0ffe768",
-  "build": "6140500",
-  "version": "6.14.0",
-  "user_agent": "Mozilla/5.0 BiliDroid/6.14.0(bbcallen@gmail.com) os/android model/MI 9 mobi_app/android build/6140500 channel/master innerVer/6140500 osVer/10 network/2"
+  "build": "6200400",
+  "version": "6.20.0",
+  "user_agent": "Mozilla/5.0 BiliDroid/6.20.0(bbcallen@gmail.com) os/android model/MI 9 mobi_app/android build/6200400 channel/master innerVer/6200400 osVer/10 network/2"
 }


### PR DESCRIPTION
* fixes:
     1. 修复了由于破站改接口导致无法通过密码登录的问题。(fixes #74)

[General]
1. 登录接口信息更新到安卓版本6.20.0